### PR TITLE
feat: prettier use cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "nuxt build -c ./configs/nuxt.config.js",
     "start": "nuxt start -c ./configs/nuxt.config.js",
     "generate": "nuxt generate -c ./configs/nuxt.config.js",
-    "prettier": "prettier --config ./configs/.prettierrc --ignore-path ./.gitignore",
+    "prettier": "prettier --config ./configs/.prettierrc --ignore-path ./.gitignore --cache --cache-strategy content",
     "eslint": "eslint --ignore-path .gitignore . -c ./configs/.eslintrc.js --cache --cache-location node_modules/.cache/eslint/ --cache-strategy content",
     "stylelint": "stylelint --ignore-path .gitignore --config ./configs/stylelint.config.js --cache --cache-location node_modules/.cache/stylelint/",
     "commitlint": "commitlint -g ./configs/commitlint.config.js",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "husky": "^8.0.1",
     "lint-staged": "^13.0.3",
     "postcss-html": "^1.3.0",
-    "prettier": "^2.5.1",
+    "prettier": "^2.7.1",
     "stylelint": "^14.11.0",
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-recommended-vue": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8529,7 +8529,7 @@ prepend-http@^1.0.0:
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-1.0.4.tgz#d4f4562b0ce3696e41ac52d0e002e57a635dc6dc"
   integrity sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==
 
-"prettier@^1.18.2 || ^2.0.0", prettier@^2.5.1:
+"prettier@^1.18.2 || ^2.0.0", prettier@^2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==


### PR DESCRIPTION
https://zenn.dev/sosukesuzuki/articles/1d1bfb73118a9b
上記を参考にprettierの結果をキャッシュするようにした。

https://github.com/prettier/prettier/blob/cd3e530c2e51fb8296c0fb7738a9afdd3a3a4410/src/cli/find-cache-file.js#L10
キャッシュ場所はこちらに書いてあるように `node_modules/.cache/prettier/.prettier-cache`